### PR TITLE
Add ability to change embed emoji in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ After cloning the repository, the only setup that needs to be done involves crea
   "serverID": "693277318496920420",
   "channelID": "461248569698208129",
   "reactionEmoji": "⭐",
+  "embedEmoji": "⭐",
   "threshold": 15,
   "hexcolor": "00AE86",
   "dateCutoff": 3,
@@ -25,6 +26,8 @@ After cloning the repository, the only setup that needs to be done involves crea
 **channelID:** the ID of the channel you want the starboard bot to post to. You can right click the channel name and obtain the channel ID after enabling developer mode.
 
 **reactionEmoji:** the emoji you want the bot to listen to. For default emojis, use the literal emoji. To easily obtain this, you can put a `\` infront of any emoji name like `\:star:` in discord (which would create ⭐). For custom emojis, simply put the exact name like `moon2SMUG`.
+
+**embedEmoji:** the emoji (Or any other piece of text) displayed at the bottom of the embeds in the starboard channel.
 
 **threshhold:** the amount of reactions it takes for a message to be posted to the starboard.
 

--- a/config/settings.json.example
+++ b/config/settings.json.example
@@ -3,6 +3,7 @@
   "serverID": "693277318496920420",
   "channelID": "461248569698208129",
   "reactionEmoji": "⭐",
+  "embedEmoji": "⭐",
   "threshold": 15,
   "hexcolor": "00AE86",
   "dateCutoff": 3,

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const client = new Discord.Client({
 })
 
 // emoji that goes in the post title
-const tt = '⭐'
+let tt = '⭐'
 let settings
 let db
 let guildID = ''
@@ -30,6 +30,9 @@ function setup () {
 
   if (settings.sql)
     db = require('./database/sequelize')
+
+  if (settings.embedEmoji)
+    tt = settings.embedEmoji
 
   // login to discord
   if (settings.token) {

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,6 @@ const client = new Discord.Client({
   partials: ['MESSAGE', 'REACTION']
 })
 
-// emoji that goes in the post title
-let tt = '⭐'
 let settings
 let db
 let guildID = ''
@@ -31,8 +29,8 @@ function setup () {
   if (settings.sql)
     db = require('./database/sequelize')
 
-  if (settings.embedEmoji)
-    tt = settings.embedEmoji
+  if (!settings.embedEmoji)
+    settings.embedEmoji = '⭐'
 
   // login to discord
   if (settings.token) {
@@ -113,7 +111,7 @@ function manageBoard (reaction_orig) {
           if (messagePosted[msg.id]) {
             const editableMessageID = messagePosted[msg.id]
             console.log(`updating count of message with ID ${editableMessageID}. reaction count: ${reaction.count}`)
-            const messageFooter = `${reaction.count} ${tt} (${msg.id})`
+            const messageFooter = `${reaction.count} ${settings.embedEmoji} (${msg.id})`
             postChannel.messages.fetch(editableMessageID).then((message) => {
               message.embeds[0].setFooter(messageFooter)
               message.edit(message.embeds[0])
@@ -133,7 +131,7 @@ function manageBoard (reaction_orig) {
             const avatarURL = `https://cdn.discordapp.com/avatars/${msg.author.id}/${msg.author.avatar}.jpg`
             const embeds = msg.embeds
             const attachments = msg.attachments
-            const messageFooter = `${reaction.count} ${tt} (${msg.id})`
+            const messageFooter = `${reaction.count} ${settings.embedEmoji} (${msg.id})`
             let eURL = ''
 
             if (embeds.length > 0) {


### PR DESCRIPTION
Another thing that I changed locally and was curious whether it was worth upstreaming:

So basically, even when I change the emoji used by the bot in the config, it will still use ⭐ in the embed:
![image](https://user-images.githubusercontent.com/14004943/97664544-75ce9980-1a72-11eb-84e9-3d8dd816e8a5.png)

This change adds a new config option, `embedEmoji`, that lets you change the text used there.
I only refer to it as an emoji in the config name because the comment above its declaration in the code described it as `emoji that goes in the post title`.

But it can in fact be any string:
![image](https://user-images.githubusercontent.com/14004943/97665251-e675b600-1a72-11eb-931d-614b5383973f.png)


The change is backwards compatible with old configs since it uses the default of ⭐ if the new option isn't present. Thus it shouldn't break anything for existing users while providing greater customization to new ones without having to modify the code.
To achieve it I had to change `const tt` to `let tt`, i hope that isn't too big of a deal.
