### PR TITLE
feat: add support for voice text channels, gif profile pictures, and tenor gifs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "discord.js": "^13.7.0",
+        "discord.js": "^13.8.0",
         "mariadb": "^2.5.4",
         "node-fetch": "^3.1.1",
         "sequelize": "^6.3.5",
@@ -17,30 +17,25 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.13.0.tgz",
-      "integrity": "sha512-4L9y26KRNNU8Y7J78SRUN1Uhava9D8jfit/YqEaKi8gQRc7PdqKqk2poybo6RXaiyt/BgKYPfcjxT7WvzGfYCA==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.14.0.tgz",
+      "integrity": "sha512-+fqLIqa9wN3R+kvlld8sgG0nt04BAZxdCDP4t2qZ9TJsquLWA+xMtT8Waibb3d4li4AQS+IOfjiHAznv/dhHgQ==",
       "dependencies": {
-        "@sapphire/shapeshift": "^2.0.0",
+        "@sapphire/shapeshift": "^3.1.0",
         "@sindresorhus/is": "^4.6.0",
-        "discord-api-types": "^0.31.1",
+        "discord-api-types": "^0.33.3",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.1",
-        "tslib": "^2.3.1"
+        "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=16.9.0"
       }
     },
-    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
-      "version": "0.31.2",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.31.2.tgz",
-      "integrity": "sha512-gpzXTvFVg7AjKVVJFH0oJGC0q0tO34iJGSHZNz9u3aqLxlD6LfxEs9wWVVikJqn9gra940oUTaPFizCkRDcEiA=="
-    },
     "node_modules/@discordjs/collection": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.6.0.tgz",
-      "integrity": "sha512-Ieaetb36l0nmAS5X9Upqk4W7euAO6FdXPxn3I8vBAKEcoIzEZI1mcVcPfCfagGJZSgBKpENnAnKkP4GAn+MV8w==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
+      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==",
       "engines": {
         "node": ">=16.9.0"
       }
@@ -55,9 +50,9 @@
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-2.2.0.tgz",
-      "integrity": "sha512-UEnKgMlQyI0yY/q+lCMX0VJft9y86IsesgbIQj6e62FBYSaMVr+IaMNpi4z45Q14VnuMACbK0yrbHISNqgUYcQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.1.0.tgz",
+      "integrity": "sha512-PkxFXd3QJ1qAPS05Dy2UkVGYPm/asF1Ugt2Xyzmv4DHzO3+G7l+873C4XFFcJ9M5Je+eCMC7SSifgPTSur5QuA==",
       "engines": {
         "node": ">=v15.0.0",
         "npm": ">=7.0.0"
@@ -189,24 +184,24 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.30.0.tgz",
-      "integrity": "sha512-wYst0jrT8EJs2tVlwUTQ2xT0oWMjUrRMpFTkNY3NMleWyQNHgWaKhqFfxdLPdC2im9IuR5EsxcEgjhf/npeftw=="
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
+      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
     },
     "node_modules/discord.js": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.7.0.tgz",
-      "integrity": "sha512-iV/An3FEB/CiBGdjWHRtgskM4UuWPq5vjhjKsrQhdVU16dbKrBxA+eIV2HWA07B3tXUGM6eco1wkr42gxxV1BA==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.8.0.tgz",
+      "integrity": "sha512-EPAA/2VLycYN5wSzavqa4iJ6qj3UtQFtHw5TH/60Fj29ymfEsCQVn//o1mTpwDxzwb+rPIrWhkxKIGGnjfv0Iw==",
       "dependencies": {
-        "@discordjs/builders": "^0.13.0",
-        "@discordjs/collection": "^0.6.0",
+        "@discordjs/builders": "^0.14.0",
+        "@discordjs/collection": "^0.7.0",
         "@sapphire/async-queue": "^1.3.1",
         "@types/node-fetch": "^2.6.1",
         "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.30.0",
+        "discord-api-types": "^0.33.3",
         "form-data": "^4.0.0",
         "node-fetch": "^2.6.1",
-        "ws": "^8.6.0"
+        "ws": "^8.7.0"
       },
       "engines": {
         "node": ">=16.6.0",
@@ -630,29 +625,22 @@
   },
   "dependencies": {
     "@discordjs/builders": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.13.0.tgz",
-      "integrity": "sha512-4L9y26KRNNU8Y7J78SRUN1Uhava9D8jfit/YqEaKi8gQRc7PdqKqk2poybo6RXaiyt/BgKYPfcjxT7WvzGfYCA==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.14.0.tgz",
+      "integrity": "sha512-+fqLIqa9wN3R+kvlld8sgG0nt04BAZxdCDP4t2qZ9TJsquLWA+xMtT8Waibb3d4li4AQS+IOfjiHAznv/dhHgQ==",
       "requires": {
-        "@sapphire/shapeshift": "^2.0.0",
+        "@sapphire/shapeshift": "^3.1.0",
         "@sindresorhus/is": "^4.6.0",
-        "discord-api-types": "^0.31.1",
+        "discord-api-types": "^0.33.3",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.1",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "discord-api-types": {
-          "version": "0.31.2",
-          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.31.2.tgz",
-          "integrity": "sha512-gpzXTvFVg7AjKVVJFH0oJGC0q0tO34iJGSHZNz9u3aqLxlD6LfxEs9wWVVikJqn9gra940oUTaPFizCkRDcEiA=="
-        }
+        "tslib": "^2.4.0"
       }
     },
     "@discordjs/collection": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.6.0.tgz",
-      "integrity": "sha512-Ieaetb36l0nmAS5X9Upqk4W7euAO6FdXPxn3I8vBAKEcoIzEZI1mcVcPfCfagGJZSgBKpENnAnKkP4GAn+MV8w=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
+      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA=="
     },
     "@sapphire/async-queue": {
       "version": "1.3.1",
@@ -660,9 +648,9 @@
       "integrity": "sha512-FFTlPOWZX1kDj9xCAsRzH5xEJfawg1lNoYAA+ecOWJMHOfiZYb1uXOI3ne9U4UILSEPwfE68p3T9wUHwIQfR0g=="
     },
     "@sapphire/shapeshift": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-2.2.0.tgz",
-      "integrity": "sha512-UEnKgMlQyI0yY/q+lCMX0VJft9y86IsesgbIQj6e62FBYSaMVr+IaMNpi4z45Q14VnuMACbK0yrbHISNqgUYcQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.1.0.tgz",
+      "integrity": "sha512-PkxFXd3QJ1qAPS05Dy2UkVGYPm/asF1Ugt2Xyzmv4DHzO3+G7l+873C4XFFcJ9M5Je+eCMC7SSifgPTSur5QuA=="
     },
     "@sindresorhus/is": {
       "version": "4.6.0",
@@ -763,24 +751,24 @@
       "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
     },
     "discord-api-types": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.30.0.tgz",
-      "integrity": "sha512-wYst0jrT8EJs2tVlwUTQ2xT0oWMjUrRMpFTkNY3NMleWyQNHgWaKhqFfxdLPdC2im9IuR5EsxcEgjhf/npeftw=="
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
+      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
     },
     "discord.js": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.7.0.tgz",
-      "integrity": "sha512-iV/An3FEB/CiBGdjWHRtgskM4UuWPq5vjhjKsrQhdVU16dbKrBxA+eIV2HWA07B3tXUGM6eco1wkr42gxxV1BA==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.8.0.tgz",
+      "integrity": "sha512-EPAA/2VLycYN5wSzavqa4iJ6qj3UtQFtHw5TH/60Fj29ymfEsCQVn//o1mTpwDxzwb+rPIrWhkxKIGGnjfv0Iw==",
       "requires": {
-        "@discordjs/builders": "^0.13.0",
-        "@discordjs/collection": "^0.6.0",
+        "@discordjs/builders": "^0.14.0",
+        "@discordjs/collection": "^0.7.0",
         "@sapphire/async-queue": "^1.3.1",
         "@types/node-fetch": "^2.6.1",
         "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.30.0",
+        "discord-api-types": "^0.33.3",
         "form-data": "^4.0.0",
         "node-fetch": "^2.6.1",
-        "ws": "^8.6.0"
+        "ws": "^8.7.0"
       },
       "dependencies": {
         "node-fetch": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Rushnett",
   "license": "MIT",
   "dependencies": {
-    "discord.js": "^13.7.0",
+    "discord.js": "^13.8.0",
     "mariadb": "^2.5.4",
     "node-fetch": "^3.1.1",
     "sequelize": "^6.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starboard",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "discord bot for creating a starboard in a server",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,7 @@ function manageBoard (reaction) {
         data.imageURL = imgs[0]
 
         // tenor gif fix (experimental)
-        data.imageURL = data.imageURL.replace(/(https:\/\/media.tenor.com\/.*)(AAAAD\/)(.*)(\.png|\.jpg)/, "$1AAAAC/$2.gif")
+        data.imageURL = data.imageURL.replace(/(^https:\/\/media.tenor.com\/.*)(AAAAD\/)(.*)(\.png|\.jpg)/, "$1AAAAC/$3.gif")
 
         // twitch clip check
         const videoEmbed = msg.embeds.filter(embed => embed.type === 'video')[0]

--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,7 @@ function manageBoard (reaction) {
       console.log(`updating count of message with ID ${editableMessageID}. reaction count: ${reaction.count}`)
       const messageFooter = `${reaction.count} ${settings.embedEmoji} (${msg.id})`
       postChannel.messages.fetch(editableMessageID).then(message => {
-        message.embeds[0].setFooter(messageFooter)
+        message.embeds[0].setFooter({ text: messageFooter, iconURL: null })
         message.edit({ embeds: [message.embeds[0]] })
 
         // if db
@@ -142,7 +142,7 @@ function manageBoard (reaction) {
       // create content data
       const data = {
         content: (msg.content.length < 3920) ? msg.content : `${msg.content.substring(0, 3920)} **[ ... ]**`,
-        avatarURL: `https://cdn.discordapp.com/avatars/${msg.author.id}/${msg.author.avatar}.jpg`,
+        avatarURL: msg.author.displayAvatarURL({ dynamic: true }),
         imageURL: '',
         footer: `${reaction.count} ${settings.embedEmoji} (${msg.id})`
       }
@@ -159,6 +159,9 @@ function manageBoard (reaction) {
           .map(embed => (embed.thumbnail) ? embed.thumbnail.url : embed.image.url)
         data.imageURL = imgs[0]
 
+        // tenor gif fix (experimental)
+        data.imageURL = data.imageURL.replace(/(https:\/\/media.tenor.com\/.*)(AAAAD\/)(.*)(\.png|\.jpg)/, "$1AAAAC/$2.gif")
+
         // twitch clip check
         const videoEmbed = msg.embeds.filter(embed => embed.type === 'video')[0]
         if (videoEmbed && videoEmbed.video.url.includes("clips.twitch.tv")) {
@@ -171,12 +174,12 @@ function manageBoard (reaction) {
       }
 
       const embed = new Discord.MessageEmbed()
-        .setAuthor(msg.author.username, data.avatarURL)
+        .setAuthor({ name: msg.author.username, iconURL: data.avatarURL, url: data.avatarURL })
         .setColor(settings.hexcolor)
         .setDescription(data.content)
         .setImage(data.imageURL)
         .setTimestamp(new Date())
-        .setFooter(data.footer)
+        .setFooter({ text: data.footer, iconURL: null })
       postChannel.send({ embeds: [embed] }).then(starMessage => {
         messagePosted[msg.id] = starMessage.id
 


### PR DESCRIPTION
## Description
This merge adds support for voice text channels, gif profile pictures, and tenor gifs. Discord.js was updated to 13.8 so running `npm install` is required for this update.

## Changes
- Updated Discord.js to 13.8.0
- Changed how profile pictures are fetched
- Added experimental tenor gif support (bot-created discord embeds don't allow you to edit the video property, so I had to be a little creative in getting the actual gif link and not the png/gifv/mp4 link). Needs additional testing.