### PR TITLE
fix(fetch): fix issue where message IDs with length > 18 would not be fetched

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -360,9 +360,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "engines": {
         "node": "*"
       }
@@ -877,9 +877,9 @@
       }
     },
     "moment": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "moment-timezone": {
       "version": "0.5.34",

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ async function * messagesIterator (channel, messagesLeft) {
   let done = false
   while (messagesLeft > 0) {
     process.stdout.write(".")
-    const messages = await channel.messages.fetch({ limit: 100, before })
+    const messages = await channel.messages.fetch({ limit: (messagesLeft < 100) ? messagesLeft : 100, before })
     if (messages.size > 0) {
       before = messages.lastKey()
       messagesLeft = messagesLeft - 100
@@ -86,7 +86,7 @@ async function loadIntoMemory () {
   for await (const message of loadMessages(channel, amount)) {
     // verify footer exists and grab original message ID
     if (message.embeds.length > 0 && message.embeds[0].footer) {
-      const footerID = String(message.embeds[0].footer.text).match(/\((\d{18})\)/)
+      const footerID = String(message.embeds[0].footer.text).match(/\((\d{18,})\)/)
       if (footerID) {
         // save post to memory
         messagePosted[footerID[1]] = message.id // starboard msg id


### PR DESCRIPTION
This merge fixes issues where messages with IDs that have length of over 18 digits would not be fetched properly. **Your bot will double post messages if you do not have this fix**.

For some reason I did not think the day would come where discord message IDs would ever reach the point where they move to 19 digit length, but that day has come. Very sorry for inconvenience.


discord.js v14 support soon~