### PR TITLE
v1.6.1: displaying multiple images and bug fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
-        "discord.js": "^14.3.0",
+        "discord.js": "^14.7.1",
         "mariadb": "^2.5.4",
         "node-fetch": "^3.1.1",
         "sequelize": "^6.3.5",
@@ -17,41 +17,51 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.2.0.tgz",
-      "integrity": "sha512-ARy4BUTMU+S0ZI6605NDqfWO+qZqV2d/xfY32z3hVSsd9IaAKJBZ1ILTZLy87oIjW8+gUpQmk9Kt0ZP9bmmd8Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.4.0.tgz",
+      "integrity": "sha512-nEeTCheTTDw5kO93faM1j8ZJPonAX86qpq/QVoznnSa8WWcCgJpjlu6GylfINTDW6o7zZY0my2SYdxx2mfNwGA==",
       "dependencies": {
-        "@sapphire/shapeshift": "^3.5.1",
-        "discord-api-types": "^0.37.3",
+        "@discordjs/util": "^0.1.0",
+        "@sapphire/shapeshift": "^3.7.1",
+        "discord-api-types": "^0.37.20",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.1",
-        "tslib": "^2.4.0"
+        "ts-mixer": "^6.0.2",
+        "tslib": "^2.4.1"
       },
       "engines": {
         "node": ">=16.9.0"
       }
     },
     "node_modules/@discordjs/collection": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.1.0.tgz",
-      "integrity": "sha512-PQ2Bv6pnT7aGPCKWbvvNRww5tYCGpggIQVgpuF9TdDPeR6n6vQYxezXiLVOS9z2B62Dp4c+qepQ15SgJbLYtCQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.3.0.tgz",
+      "integrity": "sha512-ylt2NyZ77bJbRij4h9u/wVy7qYw/aDqQLWnadjvDqW/WoWCxrsX6M3CIw9GVP5xcGCDxsrKj5e0r5evuFYwrKg==",
       "engines": {
         "node": ">=16.9.0"
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.1.0.tgz",
-      "integrity": "sha512-yCrthRTQeUyNThQEpCk7bvQJlwQmz6kU0tf3dcWBv2WX3Bncl41x7Wc+v5b5OsIxfNYq38PvVtWircu9jtYZug==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.5.0.tgz",
+      "integrity": "sha512-lXgNFqHnbmzp5u81W0+frdXN6Etf4EUi8FAPcWpSykKd8hmlWh1xy6BmE0bsJypU1pxohaA8lQCgp70NUI3uzA==",
       "dependencies": {
-        "@discordjs/collection": "^1.0.1",
+        "@discordjs/collection": "^1.3.0",
+        "@discordjs/util": "^0.1.0",
         "@sapphire/async-queue": "^1.5.0",
         "@sapphire/snowflake": "^3.2.2",
-        "discord-api-types": "^0.37.3",
-        "file-type": "^17.1.6",
-        "tslib": "^2.4.0",
-        "undici": "^5.9.1"
+        "discord-api-types": "^0.37.23",
+        "file-type": "^18.0.0",
+        "tslib": "^2.4.1",
+        "undici": "^5.13.0"
       },
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
+      "integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ==",
       "engines": {
         "node": ">=16.9.0"
       }
@@ -66,12 +76,12 @@
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.6.0.tgz",
-      "integrity": "sha512-tu2WLRdo5wotHRvsCkspg3qMiP6ETC3Q1dns1Q5V6zKUki+1itq6AbhMwohF9ZcLoYqg+Y8LkgRRtVxxTQVTBQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.8.1.tgz",
+      "integrity": "sha512-xG1oXXBhCjPKbxrRTlox9ddaZTvVpOhYLmKmApD/vIWOV1xEYXnpoFs68zHIZBGbqztq6FrUPNPerIrO1Hqeaw==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
-        "lodash.uniqwith": "^4.5.0"
+        "lodash": "^4.17.21"
       },
       "engines": {
         "node": ">=v14.0.0",
@@ -79,9 +89,9 @@
       }
     },
     "node_modules/@sapphire/snowflake": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.2.2.tgz",
-      "integrity": "sha512-ula2O0kpSZtX9rKXNeQMrHwNd7E4jPDJYUXmEGTFdMRfyfMw+FPyh04oKMjAiDuOi64bYgVkOV3MjK+loImFhQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.4.0.tgz",
+      "integrity": "sha512-zZxymtVO6zeXVMPds+6d7gv/OfnCc25M1Z+7ZLB0oPmeMTPeRWVPQSS16oDJy5ZsyCOLj7M6mbZml5gWXcVRNw==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -128,6 +138,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
@@ -161,26 +182,27 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.8",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.8.tgz",
-      "integrity": "sha512-uhol9KQ2moExZItMpuDMkf0R7sqqNHqcJBFN7S5iSdXBVCMRO7sC0GoyuRrv6ZDBYxoFU6nDy4dv0nld/aysqA=="
+      "version": "0.37.35",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.35.tgz",
+      "integrity": "sha512-iyKZ/82k7FX3lcmHiAvvWu5TmyfVo78RtghBV/YsehK6CID83k5SI03DKKopBcln+TiEIYw5MGgq7SJXSpNzMg=="
     },
     "node_modules/discord.js": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.3.0.tgz",
-      "integrity": "sha512-CpIwoAAuELiHSgVKRMzsCADS6ZlJwAZ9RlvcJYdEgS00aW36dSvXyBgE+S3pigkc7G+jU6BEalMUWIJFveqrBQ==",
+      "version": "14.7.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.7.1.tgz",
+      "integrity": "sha512-1FECvqJJjjeYcjSm0IGMnPxLqja/pmG1B0W2l3lUY2Gi4KXiyTeQmU1IxWcbXHn2k+ytP587mMWqva2IA87EbA==",
       "dependencies": {
-        "@discordjs/builders": "^1.2.0",
-        "@discordjs/collection": "^1.1.0",
-        "@discordjs/rest": "^1.1.0",
+        "@discordjs/builders": "^1.4.0",
+        "@discordjs/collection": "^1.3.0",
+        "@discordjs/rest": "^1.4.0",
+        "@discordjs/util": "^0.1.0",
         "@sapphire/snowflake": "^3.2.2",
         "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.37.3",
+        "discord-api-types": "^0.37.20",
         "fast-deep-equal": "^3.1.3",
         "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.4.0",
-        "undici": "^5.9.1",
-        "ws": "^8.8.1"
+        "tslib": "^2.4.1",
+        "undici": "^5.13.0",
+        "ws": "^8.11.0"
       },
       "engines": {
         "node": ">=16.9.0"
@@ -219,16 +241,16 @@
       }
     },
     "node_modules/file-type": {
-      "version": "17.1.6",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.6.tgz",
-      "integrity": "sha512-hlDw5Ev+9e883s0pwUsuuYNu4tD7GgpUnOvykjv1Gya0ZIjuKumthDRua90VUn6/nlRKAjcxLUnHNTIUWwWIiw==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.2.1.tgz",
+      "integrity": "sha512-Yw5MtnMv7vgD2/6Bjmmuegc8bQEVA9GmAyaR18bMYWKqsWDG9wgYZ1j4I6gNMF5Y5JBDcUcjRQqNQx7Y8uotcg==",
       "dependencies": {
         "readable-web-to-node-stream": "^3.0.2",
-        "strtok3": "^7.0.0-alpha.9",
-        "token-types": "^5.0.0-alpha.2"
+        "strtok3": "^7.0.0",
+        "token-types": "^5.0.1"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
@@ -297,11 +319,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
-    },
-    "node_modules/lodash.uniqwith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
-      "integrity": "sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q=="
     },
     "node_modules/long": {
       "version": "5.2.0",
@@ -421,9 +438,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -449,9 +466,9 @@
       }
     },
     "node_modules/retry-as-promised": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-5.0.0.tgz",
-      "integrity": "sha512-6S+5LvtTl2ggBumk04hBo/4Uf6fRJUwIgunGZ7CYEBCeufGFW1Pu6ucUf/UskHeWOIsUcLOGLFXPig5tR5V1nA=="
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
+      "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -497,9 +514,9 @@
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "node_modules/sequelize": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.20.1.tgz",
-      "integrity": "sha512-1YBMv++Yy1JBFFiac1Xoa+Km5qV6YI1ckdkW0xyD7IpLMtE5JmjgZdZXGfwgRUNjhaKMxdzT+nkvJgeXO0rv/g==",
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.29.0.tgz",
+      "integrity": "sha512-m8Wi90rs3NZP9coXE52c7PL4Q078nwYZXqt1IxPvgki7nOFn0p/F0eKsYDBXCPw9G8/BCEa6zZNk0DQUAT4ypA==",
       "funding": [
         {
           "type": "opencollective",
@@ -514,9 +531,9 @@
         "inflection": "^1.13.2",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
-        "moment-timezone": "^0.5.34",
+        "moment-timezone": "^0.5.35",
         "pg-connection-string": "^2.5.0",
-        "retry-as-promised": "^5.0.0",
+        "retry-as-promised": "^7.0.3",
         "semver": "^7.3.5",
         "sequelize-pool": "^7.1.0",
         "toposort-class": "^1.0.1",
@@ -535,6 +552,9 @@
           "optional": true
         },
         "mysql2": {
+          "optional": true
+        },
+        "oracledb": {
           "optional": true
         },
         "pg": {
@@ -566,6 +586,14 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -613,19 +641,22 @@
       "integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg="
     },
     "node_modules/ts-mixer": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.1.tgz",
-      "integrity": "sha512-hvE+ZYXuINrx6Ei6D6hz+PTim0Uf++dYbK9FFifLNwQj+RwKquhQpn868yZsCtJYiclZF1u8l6WZxxKi+vv7Rg=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
+      "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/undici": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
-      "integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
       "engines": {
         "node": ">=12.18"
       }
@@ -668,15 +699,15 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -695,35 +726,42 @@
   },
   "dependencies": {
     "@discordjs/builders": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.2.0.tgz",
-      "integrity": "sha512-ARy4BUTMU+S0ZI6605NDqfWO+qZqV2d/xfY32z3hVSsd9IaAKJBZ1ILTZLy87oIjW8+gUpQmk9Kt0ZP9bmmd8Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.4.0.tgz",
+      "integrity": "sha512-nEeTCheTTDw5kO93faM1j8ZJPonAX86qpq/QVoznnSa8WWcCgJpjlu6GylfINTDW6o7zZY0my2SYdxx2mfNwGA==",
       "requires": {
-        "@sapphire/shapeshift": "^3.5.1",
-        "discord-api-types": "^0.37.3",
+        "@discordjs/util": "^0.1.0",
+        "@sapphire/shapeshift": "^3.7.1",
+        "discord-api-types": "^0.37.20",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.1",
-        "tslib": "^2.4.0"
+        "ts-mixer": "^6.0.2",
+        "tslib": "^2.4.1"
       }
     },
     "@discordjs/collection": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.1.0.tgz",
-      "integrity": "sha512-PQ2Bv6pnT7aGPCKWbvvNRww5tYCGpggIQVgpuF9TdDPeR6n6vQYxezXiLVOS9z2B62Dp4c+qepQ15SgJbLYtCQ=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.3.0.tgz",
+      "integrity": "sha512-ylt2NyZ77bJbRij4h9u/wVy7qYw/aDqQLWnadjvDqW/WoWCxrsX6M3CIw9GVP5xcGCDxsrKj5e0r5evuFYwrKg=="
     },
     "@discordjs/rest": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.1.0.tgz",
-      "integrity": "sha512-yCrthRTQeUyNThQEpCk7bvQJlwQmz6kU0tf3dcWBv2WX3Bncl41x7Wc+v5b5OsIxfNYq38PvVtWircu9jtYZug==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.5.0.tgz",
+      "integrity": "sha512-lXgNFqHnbmzp5u81W0+frdXN6Etf4EUi8FAPcWpSykKd8hmlWh1xy6BmE0bsJypU1pxohaA8lQCgp70NUI3uzA==",
       "requires": {
-        "@discordjs/collection": "^1.0.1",
+        "@discordjs/collection": "^1.3.0",
+        "@discordjs/util": "^0.1.0",
         "@sapphire/async-queue": "^1.5.0",
         "@sapphire/snowflake": "^3.2.2",
-        "discord-api-types": "^0.37.3",
-        "file-type": "^17.1.6",
-        "tslib": "^2.4.0",
-        "undici": "^5.9.1"
+        "discord-api-types": "^0.37.23",
+        "file-type": "^18.0.0",
+        "tslib": "^2.4.1",
+        "undici": "^5.13.0"
       }
+    },
+    "@discordjs/util": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
+      "integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ=="
     },
     "@sapphire/async-queue": {
       "version": "1.5.0",
@@ -731,18 +769,18 @@
       "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA=="
     },
     "@sapphire/shapeshift": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.6.0.tgz",
-      "integrity": "sha512-tu2WLRdo5wotHRvsCkspg3qMiP6ETC3Q1dns1Q5V6zKUki+1itq6AbhMwohF9ZcLoYqg+Y8LkgRRtVxxTQVTBQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.8.1.tgz",
+      "integrity": "sha512-xG1oXXBhCjPKbxrRTlox9ddaZTvVpOhYLmKmApD/vIWOV1xEYXnpoFs68zHIZBGbqztq6FrUPNPerIrO1Hqeaw==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
-        "lodash.uniqwith": "^4.5.0"
+        "lodash": "^4.17.21"
       }
     },
     "@sapphire/snowflake": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.2.2.tgz",
-      "integrity": "sha512-ula2O0kpSZtX9rKXNeQMrHwNd7E4jPDJYUXmEGTFdMRfyfMw+FPyh04oKMjAiDuOi64bYgVkOV3MjK+loImFhQ=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.4.0.tgz",
+      "integrity": "sha512-zZxymtVO6zeXVMPds+6d7gv/OfnCc25M1Z+7ZLB0oPmeMTPeRWVPQSS16oDJy5ZsyCOLj7M6mbZml5gWXcVRNw=="
     },
     "@tokenizer/token": {
       "version": "0.3.0",
@@ -785,6 +823,14 @@
         "@types/node": "*"
       }
     },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
+    },
     "data-uri-to-buffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
@@ -804,26 +850,27 @@
       "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
     },
     "discord-api-types": {
-      "version": "0.37.8",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.8.tgz",
-      "integrity": "sha512-uhol9KQ2moExZItMpuDMkf0R7sqqNHqcJBFN7S5iSdXBVCMRO7sC0GoyuRrv6ZDBYxoFU6nDy4dv0nld/aysqA=="
+      "version": "0.37.35",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.35.tgz",
+      "integrity": "sha512-iyKZ/82k7FX3lcmHiAvvWu5TmyfVo78RtghBV/YsehK6CID83k5SI03DKKopBcln+TiEIYw5MGgq7SJXSpNzMg=="
     },
     "discord.js": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.3.0.tgz",
-      "integrity": "sha512-CpIwoAAuELiHSgVKRMzsCADS6ZlJwAZ9RlvcJYdEgS00aW36dSvXyBgE+S3pigkc7G+jU6BEalMUWIJFveqrBQ==",
+      "version": "14.7.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.7.1.tgz",
+      "integrity": "sha512-1FECvqJJjjeYcjSm0IGMnPxLqja/pmG1B0W2l3lUY2Gi4KXiyTeQmU1IxWcbXHn2k+ytP587mMWqva2IA87EbA==",
       "requires": {
-        "@discordjs/builders": "^1.2.0",
-        "@discordjs/collection": "^1.1.0",
-        "@discordjs/rest": "^1.1.0",
+        "@discordjs/builders": "^1.4.0",
+        "@discordjs/collection": "^1.3.0",
+        "@discordjs/rest": "^1.4.0",
+        "@discordjs/util": "^0.1.0",
         "@sapphire/snowflake": "^3.2.2",
         "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.37.3",
+        "discord-api-types": "^0.37.20",
         "fast-deep-equal": "^3.1.3",
         "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.4.0",
-        "undici": "^5.9.1",
-        "ws": "^8.8.1"
+        "tslib": "^2.4.1",
+        "undici": "^5.13.0",
+        "ws": "^8.11.0"
       }
     },
     "dottie": {
@@ -846,13 +893,13 @@
       }
     },
     "file-type": {
-      "version": "17.1.6",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-17.1.6.tgz",
-      "integrity": "sha512-hlDw5Ev+9e883s0pwUsuuYNu4tD7GgpUnOvykjv1Gya0ZIjuKumthDRua90VUn6/nlRKAjcxLUnHNTIUWwWIiw==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.2.1.tgz",
+      "integrity": "sha512-Yw5MtnMv7vgD2/6Bjmmuegc8bQEVA9GmAyaR18bMYWKqsWDG9wgYZ1j4I6gNMF5Y5JBDcUcjRQqNQx7Y8uotcg==",
       "requires": {
         "readable-web-to-node-stream": "^3.0.2",
-        "strtok3": "^7.0.0-alpha.9",
-        "token-types": "^5.0.0-alpha.2"
+        "strtok3": "^7.0.0",
+        "token-types": "^5.0.1"
       }
     },
     "formdata-polyfill": {
@@ -895,11 +942,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
-    },
-    "lodash.uniqwith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz",
-      "integrity": "sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q=="
     },
     "long": {
       "version": "5.2.0",
@@ -980,9 +1022,9 @@
       }
     },
     "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -998,9 +1040,9 @@
       }
     },
     "retry-as-promised": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-5.0.0.tgz",
-      "integrity": "sha512-6S+5LvtTl2ggBumk04hBo/4Uf6fRJUwIgunGZ7CYEBCeufGFW1Pu6ucUf/UskHeWOIsUcLOGLFXPig5tR5V1nA=="
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
+      "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
     },
     "safe-buffer": {
       "version": "5.2.1",
@@ -1026,9 +1068,9 @@
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "sequelize": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.20.1.tgz",
-      "integrity": "sha512-1YBMv++Yy1JBFFiac1Xoa+Km5qV6YI1ckdkW0xyD7IpLMtE5JmjgZdZXGfwgRUNjhaKMxdzT+nkvJgeXO0rv/g==",
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.29.0.tgz",
+      "integrity": "sha512-m8Wi90rs3NZP9coXE52c7PL4Q078nwYZXqt1IxPvgki7nOFn0p/F0eKsYDBXCPw9G8/BCEa6zZNk0DQUAT4ypA==",
       "requires": {
         "@types/debug": "^4.1.7",
         "@types/validator": "^13.7.1",
@@ -1037,9 +1079,9 @@
         "inflection": "^1.13.2",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
-        "moment-timezone": "^0.5.34",
+        "moment-timezone": "^0.5.35",
         "pg-connection-string": "^2.5.0",
-        "retry-as-promised": "^5.0.0",
+        "retry-as-promised": "^7.0.3",
         "semver": "^7.3.5",
         "sequelize-pool": "^7.1.0",
         "toposort-class": "^1.0.1",
@@ -1057,6 +1099,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -1090,19 +1137,22 @@
       "integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg="
     },
     "ts-mixer": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.1.tgz",
-      "integrity": "sha512-hvE+ZYXuINrx6Ei6D6hz+PTim0Uf++dYbK9FFifLNwQj+RwKquhQpn868yZsCtJYiclZF1u8l6WZxxKi+vv7Rg=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
+      "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "undici": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
-      "integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g=="
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "requires": {
+        "busboy": "^1.6.0"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -1133,9 +1183,9 @@
       }
     },
     "ws": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
       "requires": {}
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Rushnett",
   "license": "MIT",
   "dependencies": {
-    "discord.js": "^14.3.0",
+    "discord.js": "^14.7.1",
     "mariadb": "^2.5.4",
     "node-fetch": "^3.1.1",
     "sequelize": "^6.3.5",

--- a/src/index.js
+++ b/src/index.js
@@ -125,17 +125,14 @@ async function manageBoard (reaction) {
       console.log(`updating count of message with ID ${editableMessageID}. reaction count: ${reaction.count}`)
       const messageFooter = `${reaction.count} ${settings.embedEmoji} (${msg.id})`
       postChannel.messages.fetch(editableMessageID).then(message => {
-        // rebuild embed
-        const origEmbed = message.embeds[0]
-        const updatedEmbed = new EmbedBuilder()
-          .setAuthor(origEmbed.author)
-          .setColor(origEmbed.color)
-          .setDescription(origEmbed.description)
-          .setImage((origEmbed.image) ? origEmbed.image.url : null)
-          .setTimestamp(new Date(origEmbed.timestamp))
-          .setFooter({ text: messageFooter, iconURL: null })
+        // rebuild embeds
+        const origEmbed = message.embeds.shift()
+        const updatedEmbeds = [
+          EmbedBuilder.from(origEmbed)
+            .setFooter({ text: messageFooter, iconURL: null })
+        ]
 
-        message.edit({ embeds: [updatedEmbed] })
+        message.edit({ embeds: updatedEmbeds.concat(message.embeds) })
 
         // if db
         if (db)
@@ -155,7 +152,8 @@ async function manageBoard (reaction) {
         content: msg.content,
         contentInfo: '',
         avatarURL: msg.author.displayAvatarURL({ dynamic: true }),
-        imageURL: '',
+        // imageURL: '',
+        imageURLs: [],
         footer: `${reaction.count} ${settings.embedEmoji} (${msg.id})`
       }
 
@@ -185,11 +183,16 @@ async function manageBoard (reaction) {
           .map(embed => (embed.thumbnail) ? embed.thumbnail.url : embed.image.url)
 
         if (imgs.length) {
-          data.imageURL = imgs[0]
+          // data.imageURL = imgs[0]
+          data.imageURLs = imgs
 
           // site specific gif fixes
-          data.imageURL = data.imageURL.replace(/(^https:\/\/media.tenor.com\/.*)(AAAAD\/)(.*)(\.png|\.jpg)/, "$1AAAAC/$3.gif")
-          data.imageURL = data.imageURL.replace(/(^https:\/\/thumbs.gfycat.com\/.*-)(poster\.jpg)/, "$1size_restricted.gif")
+          data.imageURLs.forEach((url, i) => {
+            data.imageURLs[i] = data.imageURLs[i].replace(/(^https:\/\/media.tenor.com\/.*)(AAAAD\/)(.*)(\.png|\.jpg)/, "$1AAAAC/$3.gif")
+            data.imageURLs[i] = data.imageURLs[i].replace(/(^https:\/\/thumbs.gfycat.com\/.*-)(poster\.jpg)/, "$1size_restricted.gif")
+          })
+          // data.imageURL = data.imageURL.replace(/(^https:\/\/media.tenor.com\/.*)(AAAAD\/)(.*)(\.png|\.jpg)/, "$1AAAAC/$3.gif")
+          // data.imageURL = data.imageURL.replace(/(^https:\/\/thumbs.gfycat.com\/.*-)(poster\.jpg)/, "$1size_restricted.gif")
 
           // twitch clip check
           const videoEmbed = msg.embeds.filter(embed => embed.data.type === 'video')[0]
@@ -207,10 +210,13 @@ async function manageBoard (reaction) {
             data.content += embed.fields[0].value
           }
         }
-
-      } else if (msg.attachments.size) {
-        data.imageURL = msg.attachments.first().url
-        msg.attachments.each(attachment => data.contentInfo += `\n📎 [${attachment.name}](${attachment.url})`)
+      }
+      if (msg.attachments.size) {
+        // data.imageURL = msg.attachments.first().url
+        msg.attachments.each(attachment => {
+          data.imageURLs.push(attachment.url)
+          data.contentInfo += `\n📎 [${attachment.name}](${attachment.url})`
+        })
       }
 
       // max length message
@@ -220,14 +226,23 @@ async function manageBoard (reaction) {
       // set message embed color
       const hexcolor = (settings.hexcolor) ? settings.hexcolor : parseInt(msg.channel.id).toString(16).substring(2, 8)
 
-      const embed = new EmbedBuilder()
-        .setAuthor({ name: msg.author.username, iconURL: data.avatarURL, url: `https://discordapp.com/users/${msg.author.id}`})
-        .setColor(hexcolor)
-        .setDescription(data.content + data.contentInfo)
-        .setImage((data.imageURL) ? data.imageURL : null)
-        .setTimestamp(new Date())
-        .setFooter({ text: data.footer, iconURL: null })
-      postChannel.send({ embeds: [embed] }).then(starMessage => {
+      // attach all embeds
+      const embeds =  [
+        new EmbedBuilder()
+          .setURL("https://risu.dev/")
+          .setAuthor({ name: msg.author.username, iconURL: data.avatarURL, url: `https://discordapp.com/users/${msg.author.id}`})
+          .setColor(hexcolor)
+          .setDescription(data.content + data.contentInfo)
+          .setImage((data.imageURLs.length) ? data.imageURLs.shift() : null)
+          .setTimestamp(new Date())
+          .setFooter({ text: data.footer, iconURL: null }),
+      ]
+      data.imageURLs.forEach(url => {
+        embeds.push(new EmbedBuilder().setURL("https://risu.dev/").setImage(url))
+      })
+
+      // post embed
+      postChannel.send({ embeds: embeds }).then(starMessage => {
         messagePosted[msg.id] = starMessage.id
 
         // if db

--- a/src/index.js
+++ b/src/index.js
@@ -127,6 +127,7 @@ async function manageBoard (reaction) {
       postChannel.messages.fetch(editableMessageID).then(message => {
         // rebuild embeds
         const origEmbed = message.embeds[0]
+        if (!origEmbed) throw `original embed could not be fetched`
         const updatedEmbeds = [
           EmbedBuilder.from(origEmbed)
             .setFooter({ text: messageFooter, iconURL: null })

--- a/src/index.js
+++ b/src/index.js
@@ -132,11 +132,12 @@ async function manageBoard (reaction) {
             .setFooter({ text: messageFooter, iconURL: null })
         ]
 
-        message.edit({ embeds: updatedEmbeds.concat(message.embeds) })
+        message.edit({ embeds: updatedEmbeds.concat(message.embeds) }).then(starMessage => {
+          // if db
+          if (db)
+            db.updatePost(message, msg, reaction.count, starMessage.embeds[0].image)
+        })
 
-        // if db
-        if (db)
-          db.updatePost(message, msg, reaction.count, message.embeds[0].image)
 
       }).catch(err => {
         console.error(`error updating post: ${editableMessageID}\noriginal message: ${msg.id}\n${err}`)

--- a/src/index.js
+++ b/src/index.js
@@ -135,9 +135,8 @@ async function manageBoard (reaction) {
         message.edit({ embeds: updatedEmbeds.concat(message.embeds) }).then(starMessage => {
           // if db
           if (db)
-            db.updatePost(message, msg, reaction.count, starMessage.embeds[0].image)
+            db.updatePost(starMessage, msg, reaction.count, starMessage.embeds[0].image)
         })
-
 
       }).catch(err => {
         console.error(`error updating post: ${editableMessageID}\noriginal message: ${msg.id}\n${err}`)

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ function setup () {
 // fetches full structure if partial
 function fetchStructure(structure) {
   return new Promise((resolve, reject) => {
-    if (structure.partial) {
+    if (structure.partial || structure.count <= 1) {
       structure.fetch()
         .then((structure) => resolve(structure))
         .catch((error) => reject(error))

--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,7 @@ async function manageBoard (reaction) {
 
       // add msg origin info to content prop
       const msgLink = `https://discordapp.com/channels/${msg.guild.id}/${msg.channel.id}/${msg.id}`
-      const threadTypes = [ChannelType.GuildNewsThread, ChannelType.GuildPublicThread, ChannelType.GuildPrivateThread]
+      const threadTypes = [ChannelType.AnnouncementThread, ChannelType.PublicThread, ChannelType.PrivateThread]
       const channelLink = (threadTypes.includes(msg.channel.type)) ? `<#${msg.channel.parent.id}>/<#${msg.channel.id}>` : `<#${msg.channel.id}>`
       data.contentInfo += `\n\n→ [original message](${msgLink}) in ${channelLink}`
 

--- a/src/index.js
+++ b/src/index.js
@@ -126,13 +126,13 @@ async function manageBoard (reaction) {
       const messageFooter = `${reaction.count} ${settings.embedEmoji} (${msg.id})`
       postChannel.messages.fetch(editableMessageID).then(message => {
         // rebuild embeds
-        const origEmbed = message.embeds.shift()
+        const origEmbed = message.embeds[0]
         const updatedEmbeds = [
           EmbedBuilder.from(origEmbed)
             .setFooter({ text: messageFooter, iconURL: null })
         ]
 
-        message.edit({ embeds: updatedEmbeds.concat(message.embeds) }).then(starMessage => {
+        message.edit({ embeds: updatedEmbeds.concat(message.embeds.slice(1)) }).then(starMessage => {
           // if db
           if (db)
             db.updatePost(starMessage, msg, reaction.count, starMessage.embeds[0].image)


### PR DESCRIPTION
## v1.6.1
This update requires an `npm install` for updates

### Features
- adds ability to see up to 4 images in an embed at once

### Fixes
- apply fix to reaction desync bug
   - sometimes the reaction count for a post pulled from discordjs would reset back to 0, causing it to desync from the actual value. this would happen very randomly, and is a bit hard to reproduce with how rare it happens. the fix is to just fetch the structure again when react count is 1 or less.
- update dependencies (run `npm install`)

### Examples
Example of multiple images in an embed
![image](https://user-images.githubusercontent.com/9059594/223237117-6b6db472-9e63-4611-b87d-ac209c94e3e1.png)




