### PR TITLE
v1.6.2: allow message edits, code restructure, and bug fixes

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 - present @Rushnett
+Copyright (c) 2018 - present @naeruru
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PRIVACYPOLICY.md
+++ b/PRIVACYPOLICY.md
@@ -1,5 +1,5 @@
 # Smugboard Privacy Policy
-Last updated May 5th, 2021
+Last updated June 8th, 2023
 
 ## Introduction
 Smugboard ("this bot" or "me" or "we" or "us" or "our") collects a small amount of data when users ("users" or "you") use this bot through Discord. This Privacy Policy explains how it collects, uses, and safeguards this information. Because this is an open source project, it must be stated that this Privacy Policy strictly pertains to Smugboard (bot administered by me). Any other bots that use this repository may differ slightly from this Privacy Policy and are in no way connected with me. Please read this privacy policy carefully. If you do not agree with the terms, please do not access Discord servers with this bot ("participating servers").
@@ -37,8 +37,8 @@ Your information will never be sold to advertisers or third parties for any reas
 
 
 ## Options regarding your information
-You may at any time request deletion of your stored information. You may do this by messaging me (Rushnett) on participating servers and requesting deletion of your information. You may also create an Issue on this repository ([https://github.com/Rushnett/starboard/issues](https://github.com/Rushnett/starboard/issues)). At the time of requesting, your Discord ID will be collected in order to look up and delete your stored content on our database (searchable by said Discord ID). However, some information will be retained in the participating Discord server (commonly known as the "posting channel").
+You may at any time request deletion of your stored information. You may do this by messaging me (Rushnett) on participating servers and requesting deletion of your information. You may also create an Issue on this repository ([https://github.com/naeruru/starboard/issues](https://github.com/naeruru/starboard/issues)). At the time of requesting, your Discord ID will be collected in order to look up and delete your stored content on our database (searchable by said Discord ID). However, some information will be retained in the participating Discord server (commonly known as the "posting channel").
 
 
 ## Contact
-if you have any questions or comments about this Privacy Policy, you can create an issue on this repository at [https://github.com/Rushnett/starboard/issues](https://github.com/Rushnett/starboard/issues).
+if you have any questions or comments about this Privacy Policy, you can create an issue on this repository at [https://github.com/naeruru/starboard/issues](https://github.com/naeruru/starboard/issues).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ After creating your bot and cloning the repository, the only setup that needs to
   "threshold": 15,
   "hexcolor": "00AE86",
   "dateCutoff": 3,
-  "fetchLimit": 100
+  "fetchLimit": 100,
+  "editMsgGracePeriod": 300
 }
 ```
 
@@ -34,7 +35,7 @@ After creating your bot and cloning the repository, the only setup that needs to
 | **hexcolor** | String | the color of the embed in hex. if null, this value is generated from an incoming message's channel ID (unique color code per channel). |
 | **dateCutoff** | Integer | how old a message can be, in days, and still be tracked by the bot. if you don't want really old messages getting posted, then keep this number low. |
 | **fetchLimit** | Integer | how many messages from the starboard channel will be loaded in memory. This lets the script know what messages have already been posted. It's recommended to change this with respect to `dateCutoff` and how big your server is. Anything that isn't tracked has the possibility of getting double posted. |
-
+| **editMsgGracePeriod** | Integer | how long, in seconds, a message can to be edited to update its board post. disables this feature if set to null or 0. |
 
 ### Running the Project
 Use `npm install` to download dependencies. Finally, you can run the bot with `npm start`. I recommend using pm2 for continuous uptime.

--- a/config/settings.json.example
+++ b/config/settings.json.example
@@ -7,5 +7,6 @@
   "threshold": 15,
   "hexcolor": "00AE86",
   "dateCutoff": 3,
-  "fetchLimit": 100
+  "fetchLimit": 100,
+  "editOnMsgUpdate": true
 }

--- a/config/settings.json.example
+++ b/config/settings.json.example
@@ -8,5 +8,5 @@
   "hexcolor": "00AE86",
   "dateCutoff": 3,
   "fetchLimit": 100,
-  "editOnMsgUpdate": true
+  "editMsgGracePeriod": 300
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "starboard",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starboard",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "description": "discord bot for creating a starboard in a server",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -208,7 +208,6 @@ function editEmbed(reaction, editableMessageID, forceUpdate=false) {
       updatedEmbeds = updatedEmbeds.concat(message.embeds.slice(1))
     }
 
-    console.log(updatedEmbeds)
     message.edit({ embeds: updatedEmbeds }).then(starMessage => {
       // if db
       if (db)

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ let settings
 let db
 let guildID = ''
 let smugboardID = ''
+let postChannel
 const messagePosted = {}
 let loading = true
 
@@ -99,11 +100,131 @@ async function loadIntoMemory () {
   console.log(`\nLoaded ${Object.keys(messagePosted).length} previous posts in ${settings.reactionEmoji} channel!`)
 }
 
+async function buildEmbedFields(reaction) {
+        const msg = reaction.message
+
+        // create content data
+        const data = {
+          content: msg.content,
+          contentInfo: '',
+          avatarURL: msg.author.displayAvatarURL({ dynamic: true }),
+          // imageURL: '',
+          imageURLs: [],
+          footer: `${reaction.count} ${settings.embedEmoji} (${msg.id})`
+        }
+  
+        // add msg origin info to content prop
+        const msgLink = `https://discordapp.com/channels/${msg.guild.id}/${msg.channel.id}/${msg.id}`
+        const threadTypes = [ChannelType.AnnouncementThread, ChannelType.PublicThread, ChannelType.PrivateThread]
+        const channelLink = (threadTypes.includes(msg.channel.type)) ? `<#${msg.channel.parent.id}>/<#${msg.channel.id}>` : `<#${msg.channel.id}>`
+        data.contentInfo += `\n\n→ [original message](${msgLink}) in ${channelLink}`
+  
+        // resolve reply message
+        if (msg.reference && msg.reference.messageId) {
+          await msg.channel.messages.fetch(msg.reference.messageId).then(message => {
+            // construct reply comment
+            let replyContent = (!message.content && message.attachments.size) ? message.attachments.first().name : message.content.replace(/\n/g, ' ')
+            replyContent = (replyContent.length > 300) ? `${replyContent.substring(0, 300)}...` : replyContent
+            data.content = (msg.content) ? `\n\n${data.content}`: data.content
+            data.content = `> ${msg.mentions.repliedUser}: ${replyContent}${data.content}`
+          }).catch(err => {
+            console.error(`error getting reply msg: ${msg.reference.messageId} (for ${msg.id})\n${err}`)
+          })
+        }
+  
+        // resolve any embeds and images
+        if (msg.embeds.length) {
+          const imgs = msg.embeds
+            .filter(embed => embed.thumbnail || embed.image)
+            .map(embed => (embed.thumbnail) ? embed.thumbnail.url : embed.image.url)
+  
+          if (imgs.length) {
+            // data.imageURL = imgs[0]
+            data.imageURLs = imgs
+  
+            // site specific gif fixes
+            data.imageURLs.forEach((url, i) => {
+              data.imageURLs[i] = data.imageURLs[i].replace(/(^https:\/\/media.tenor.com\/.*)(AAAAD\/)(.*)(\.png|\.jpg)/, "$1AAAAC/$3.gif")
+              data.imageURLs[i] = data.imageURLs[i].replace(/(^https:\/\/thumbs.gfycat.com\/.*-)(poster\.jpg)/, "$1size_restricted.gif")
+            })
+            // data.imageURL = data.imageURL.replace(/(^https:\/\/media.tenor.com\/.*)(AAAAD\/)(.*)(\.png|\.jpg)/, "$1AAAAC/$3.gif")
+            // data.imageURL = data.imageURL.replace(/(^https:\/\/thumbs.gfycat.com\/.*-)(poster\.jpg)/, "$1size_restricted.gif")
+  
+            // twitch clip check
+            const videoEmbed = msg.embeds.filter(embed => embed.data.type === 'video')[0]
+            if (videoEmbed && videoEmbed.data.video.url.includes("clips.twitch.tv")) {
+              data.contentInfo += `\n⬇️ [download clip](${videoEmbed.data.thumbnail.url.replace("-social-preview.jpg", ".mp4")})`
+            }
+          }
+  
+          // message is entirely an embed (bot msg)
+          if (msg.content === '') {
+            const embed = msg.embeds[0]
+            if (embed.description) {
+              data.content += embed.description
+            } else if (embed.fields && embed.fields[0].value) {
+              data.content += embed.fields[0].value
+            }
+          }
+        }
+        if (msg.attachments.size) {
+          // data.imageURL = msg.attachments.first().url
+          msg.attachments.each(attachment => {
+            data.imageURLs.push(attachment.url)
+            data.contentInfo += `\n📎 [${attachment.name}](${attachment.url})`
+          })
+        }
+  
+        // max length message
+        if (data.content.length > MAXLENGTH - data.contentInfo.length)
+          data.content = `${data.content.substring(0, MAXLENGTH - data.contentInfo.length)}...`
+        
+        return data
+}
+
+// update embed
+function editEmbed(reaction, editableMessageID, forceUpdate=false) {
+  console.log(`updating count of message with ID ${editableMessageID}. reaction count: ${reaction.count}`)
+  const messageFooter = `${reaction.count} ${settings.embedEmoji} (${reaction.message.id})`
+  postChannel.messages.fetch(editableMessageID).then(async message => {
+    // rebuild embeds
+    const origEmbed = message.embeds[0]
+    if (!origEmbed) throw `original embed could not be fetched`
+    let updatedEmbeds = [
+      EmbedBuilder.from(origEmbed)
+        .setFooter({ text: messageFooter, iconURL: null })
+    ]
+    if (forceUpdate) {
+      const data = await buildEmbedFields(reaction)
+      const first_image = (data.imageURLs.length) ? data.imageURLs.shift() : null
+      updatedEmbeds[0]
+        .setDescription(data.content + data.contentInfo)
+        .setURL(first_image)
+        .setImage(first_image)
+      data.imageURLs.forEach(url => {
+        updatedEmbeds.push(new EmbedBuilder().setURL(first_image).setImage(url))
+      })
+    } else {
+      updatedEmbeds = updatedEmbeds.concat(message.embeds.slice(1))
+    }
+
+    console.log(updatedEmbeds)
+    message.edit({ embeds: updatedEmbeds }).then(starMessage => {
+      // if db
+      if (db)
+        db.updatePost(starMessage, msg, reaction.count, starMessage.embeds[0].image)
+    })
+
+  }).catch(err => {
+    console.error(`error updating post: ${editableMessageID}\noriginal message: ${reaction.message.id}\n${err}`)
+  })
+}
+
 // manage the message board on reaction add/remove
 async function manageBoard (reaction) {
 
   const msg = reaction.message
-  const postChannel = client.guilds.cache.get(guildID).channels.cache.get(smugboardID)
+  // const postChannel = client.guilds.cache.get(guildID).channels.cache.get(smugboardID)
 
   // if message is older than set amount
   const dateDiff = (new Date()) - msg.createdAt
@@ -122,107 +243,15 @@ async function manageBoard (reaction) {
       const editableMessageID = messagePosted[msg.id]
       if (editableMessageID === true) return // message not yet posted (too fast)
 
-      console.log(`updating count of message with ID ${editableMessageID}. reaction count: ${reaction.count}`)
-      const messageFooter = `${reaction.count} ${settings.embedEmoji} (${msg.id})`
-      postChannel.messages.fetch(editableMessageID).then(message => {
-        // rebuild embeds
-        const origEmbed = message.embeds[0]
-        if (!origEmbed) throw `original embed could not be fetched`
-        const updatedEmbeds = [
-          EmbedBuilder.from(origEmbed)
-            .setFooter({ text: messageFooter, iconURL: null })
-        ]
+      editEmbed(reaction, editableMessageID, forceUpdate=false)
 
-        message.edit({ embeds: updatedEmbeds.concat(message.embeds.slice(1)) }).then(starMessage => {
-          // if db
-          if (db)
-            db.updatePost(starMessage, msg, reaction.count, starMessage.embeds[0].image)
-        })
-
-      }).catch(err => {
-        console.error(`error updating post: ${editableMessageID}\noriginal message: ${msg.id}\n${err}`)
-      })
     } else {
       console.log(`posting message with content ID ${msg.id}. reaction count: ${reaction.count}`)
 
       // add message to ongoing object in memory
       messagePosted[msg.id] = true
 
-      // create content data
-      const data = {
-        content: msg.content,
-        contentInfo: '',
-        avatarURL: msg.author.displayAvatarURL({ dynamic: true }),
-        // imageURL: '',
-        imageURLs: [],
-        footer: `${reaction.count} ${settings.embedEmoji} (${msg.id})`
-      }
-
-      // add msg origin info to content prop
-      const msgLink = `https://discordapp.com/channels/${msg.guild.id}/${msg.channel.id}/${msg.id}`
-      const threadTypes = [ChannelType.AnnouncementThread, ChannelType.PublicThread, ChannelType.PrivateThread]
-      const channelLink = (threadTypes.includes(msg.channel.type)) ? `<#${msg.channel.parent.id}>/<#${msg.channel.id}>` : `<#${msg.channel.id}>`
-      data.contentInfo += `\n\n→ [original message](${msgLink}) in ${channelLink}`
-
-      // resolve reply message
-      if (msg.reference && msg.reference.messageId) {
-        await msg.channel.messages.fetch(msg.reference.messageId).then(message => {
-          // construct reply comment
-          let replyContent = (!message.content && message.attachments.size) ? message.attachments.first().name : message.content.replace(/\n/g, ' ')
-          replyContent = (replyContent.length > 300) ? `${replyContent.substring(0, 300)}...` : replyContent
-          data.content = (msg.content) ? `\n\n${data.content}`: data.content
-          data.content = `> ${msg.mentions.repliedUser}: ${replyContent}${data.content}`
-        }).catch(err => {
-          console.error(`error getting reply msg: ${msg.reference.messageId} (for ${msg.id})\n${err}`)
-        })
-      }
-
-      // resolve any embeds and images
-      if (msg.embeds.length) {
-        const imgs = msg.embeds
-          .filter(embed => embed.thumbnail || embed.image)
-          .map(embed => (embed.thumbnail) ? embed.thumbnail.url : embed.image.url)
-
-        if (imgs.length) {
-          // data.imageURL = imgs[0]
-          data.imageURLs = imgs
-
-          // site specific gif fixes
-          data.imageURLs.forEach((url, i) => {
-            data.imageURLs[i] = data.imageURLs[i].replace(/(^https:\/\/media.tenor.com\/.*)(AAAAD\/)(.*)(\.png|\.jpg)/, "$1AAAAC/$3.gif")
-            data.imageURLs[i] = data.imageURLs[i].replace(/(^https:\/\/thumbs.gfycat.com\/.*-)(poster\.jpg)/, "$1size_restricted.gif")
-          })
-          // data.imageURL = data.imageURL.replace(/(^https:\/\/media.tenor.com\/.*)(AAAAD\/)(.*)(\.png|\.jpg)/, "$1AAAAC/$3.gif")
-          // data.imageURL = data.imageURL.replace(/(^https:\/\/thumbs.gfycat.com\/.*-)(poster\.jpg)/, "$1size_restricted.gif")
-
-          // twitch clip check
-          const videoEmbed = msg.embeds.filter(embed => embed.data.type === 'video')[0]
-          if (videoEmbed && videoEmbed.data.video.url.includes("clips.twitch.tv")) {
-            data.contentInfo += `\n⬇️ [download clip](${videoEmbed.data.thumbnail.url.replace("-social-preview.jpg", ".mp4")})`
-          }
-        }
-
-        // message is entirely an embed (bot msg)
-        if (msg.content === '') {
-          const embed = msg.embeds[0]
-          if (embed.description) {
-            data.content += embed.description
-          } else if (embed.fields && embed.fields[0].value) {
-            data.content += embed.fields[0].value
-          }
-        }
-      }
-      if (msg.attachments.size) {
-        // data.imageURL = msg.attachments.first().url
-        msg.attachments.each(attachment => {
-          data.imageURLs.push(attachment.url)
-          data.contentInfo += `\n📎 [${attachment.name}](${attachment.url})`
-        })
-      }
-
-      // max length message
-      if (data.content.length > MAXLENGTH - data.contentInfo.length)
-        data.content = `${data.content.substring(0, MAXLENGTH - data.contentInfo.length)}...`
+      const data = await buildEmbedFields(reaction)
       
       // set first image
       const first_image = (data.imageURLs.length) ? data.imageURLs.shift() : null
@@ -258,7 +287,7 @@ async function manageBoard (reaction) {
 
 // delete a post
 function deletePost (msg) {
-  const postChannel = client.guilds.cache.get(guildID).channels.cache.get(smugboardID)
+  // const postChannel = client.guilds.cache.get(guildID).channels.cache.get(smugboardID)
   // if posted to channel board before
   if (messagePosted[msg.id]) {
     const editableMessageID = messagePosted[msg.id]
@@ -279,6 +308,7 @@ client.on('ready', () => {
   console.log(`Logged in as ${client.user.username}!`)
   guildID = settings.serverID
   smugboardID = settings.channelID
+  postChannel = client.guilds.cache.get(guildID).channels.cache.get(smugboardID)
   // fetch existing posts
   loadIntoMemory()
 })
@@ -335,6 +365,11 @@ client.on('messageDelete', (msg) => {
 client.on('messageUpdate', (oldMsg, newMsg) => {
   if (db && oldMsg.channel.id === smugboardID && oldMsg.embeds.length && !newMsg.embeds.length)
     db.setDeleted(newMsg.id)
+  else if (settings.editOnMsgUpdate && messagePosted[newMsg.id]) {
+    const reaction = newMsg.reactions.cache.get(settings.reactionEmoji)
+    // check if partial
+    if (reaction) editEmbed(reaction, messagePosted[newMsg.id], forceUpdate=true)
+  }
 })
 
 setup()

--- a/src/index.js
+++ b/src/index.js
@@ -211,7 +211,7 @@ function editEmbed(reaction, editableMessageID, forceUpdate=false) {
     message.edit({ embeds: updatedEmbeds }).then(starMessage => {
       // if db
       if (db)
-        db.updatePost(starMessage, msg, reaction.count, starMessage.embeds[0].image)
+        db.updatePost(starMessage, reaction.message, reaction.count, starMessage.embeds[0].image)
     })
 
   }).catch(err => {

--- a/src/index.js
+++ b/src/index.js
@@ -364,10 +364,18 @@ client.on('messageDelete', (msg) => {
 client.on('messageUpdate', (oldMsg, newMsg) => {
   if (db && oldMsg.channel.id === smugboardID && oldMsg.embeds.length && !newMsg.embeds.length)
     db.setDeleted(newMsg.id)
-  else if (settings.editOnMsgUpdate && messagePosted[newMsg.id]) {
+  else if (settings.editMsgGracePeriod && messagePosted[newMsg.id]) {
     const reaction = newMsg.reactions.cache.get(settings.reactionEmoji)
     // check if partial
-    if (reaction) editEmbed(reaction, messagePosted[newMsg.id], forceUpdate=true)
+    if (reaction) {
+      const dateDiff = (new Date()) - reaction.message.createdTimestamp
+      const dateCutoff = 1000
+      console.log(Math.floor(dateDiff / dateCutoff))
+      if (Math.floor(dateDiff / dateCutoff) <= settings.editMsgGracePeriod)
+        editEmbed(reaction, messagePosted[newMsg.id], forceUpdate=true)
+      else
+        console.log(`message older than ${settings.editMsgGracePeriod} seconds was edited, ignoring`)
+    }
   }
 })
 

--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,7 @@ async function loadIntoMemory () {
   console.log(`\nLoaded ${Object.keys(messagePosted).length} previous posts in ${settings.reactionEmoji} channel!`)
 }
 
+// construct json object for embed fields
 async function buildEmbedFields(reaction) {
         const msg = reaction.message
 


### PR DESCRIPTION
## the not so temp update

this update is backwards compatible. no changes need to be done for it to work as is. 

**HOWEVER**, this version is a preliminary restructure to the code. so, if your version of my code changes `manageBoard()` in `index.js` in any way, read the [restructure section](#Restructure) below!

### Features
- adds ability for a user to edit their message after their message is pinned to the board, up to a configurable amount
  - you can configure the grace period  in the config with `editMsgGracePeriod`, where 1 = 1 second. The grace period is calculated based on when the original message from the user is posted, not when the message is reposted on the board. If `editMsgGracePeriod` is 0 or null (missing), this feature is disabled.

### Fixes
- fix gif url favoriting issue where favoriting a gif would redirect to my placeholder url. now, favoriting a gif redirects to the FIRST url of the embed. sadly the star button for favoriting gifs will always redirect to the overall url of the embed, so this does not fix the issue with multiple gifs still redirecting to the first gif of the embed. this is just how discord handles embeds, but I will keep an eye on this to make updates accordingly.


### Examples

<details>

<summary>click here for example of editing a message after it has been posted</summary>

https://github.com/naexris/starboard/assets/9059594/c048de45-6f3a-4dbb-9e13-ee6c70c3bfbb

</details>


### Restructure
I've split the main logic (`manageBoard()`) into three functions. this improves its ability to reuse code for future additions (such as adding commands, file splitting, etc). I decided to hold off on slash commands for now since it would be a pretty big change and I think it is good idea to have a version before that that is fully backwards compatible with everything. plus I want more time to work out the right way to go forward so that I keep the code simple and don't add bloat at all. functions:
- `manageBoard()`
  - entry point for managing the starboard. same as before, it determines if a message should be posted, edited, or ignored
- `buildEmbedFields()`
  - manages the logic for building embeds. takes a reaction structure and builds a json object  `data` that contains all fields needed for an embed.
- `editEmbed()`
  - logic for editing an embed. takes an optional `forceUpdate` param. If `forceUpdate` is true, starboard will update the description, images, and footer of the embed. if `forceUpdate` is false, it will act as it did before and only update the footer.