### PR TITLE
docker: upgrade Node.js to 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 ADD . /app


### PR DESCRIPTION
Node.js 16 has been EOL for a while now, and 20 is the latest LTS.
Did not introduce any issues on my setup, but I didn't test everything so I suggest checking the bot works as expected on 20 if not already done.